### PR TITLE
Repaired redirected checkout BitPay invoice amount calculation

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -6,7 +6,7 @@ You must have a BitPay merchant account to use this plugin.  It's free to [sign-
 
 ## Server Requirements
 
-* Last Cart Version Tested: 1.9.0.1
+* Last Cart Version Tested: 1.9.2.1
 * [Magento CE](http://magento.com/resources/system-requirements) 1.9.0.1 or higher. Older versions might work, however this plugin has been validated to work against the 1.9.0.1 Community Edition release.
 * [GMP](http://us2.php.net/gmp) or [BC Math](http://us2.php.net/manual/en/book.bc.php) PHP extensions.  GMP is preferred for performance reasons but you may have to install this as most servers do not come with it installed by default.  BC Math is commonly installed however and the plugin will fall back to this method if GMP is not found.
 * [OpenSSL](http://us2.php.net/openssl) Must be compiled with PHP and is used for certain cryptographic operations.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To get up and running with our plugin quickly, see the GUIDE here: https://githu
 
 **BitPay Support:**
 
-* Last Cart Version Tested: 1.9.0.1
+* Last Cart Version Tested: 1.9.2.1
 * [GitHub Issues](https://github.com/bitpay/magento-plugin/issues)
   * Open an issue if you are having issues with this plugin.
 * [Support](https://help.bitpay.com)

--- a/app/code/community/Bitpay/Core/Model/Method/Bitcoin.php
+++ b/app/code/community/Bitpay/Core/Model/Method/Bitcoin.php
@@ -37,6 +37,15 @@ class Bitpay_Core_Model_Method_Bitcoin extends Mage_Payment_Model_Method_Abstrac
      */
     public function authorize(Varien_Object $payment, $amount, $iframe = false)
     {
+        if (false === isset($payment) || false === isset($amount) || true === empty($payment) || true === empty($amount)) {
+            $this->debugData('[ERROR] In Bitpay_Core_Model_Method_Bitcoin::authorize(): missing payment or amount parameters.');
+            throw new \Exception('In Bitpay_Core_Model_Method_Bitcoin::authorize(): missing payment or amount parameters.');
+        }
+
+        if ($iframe === false) {
+            $amount = $payment->getOrder()->getQuote()->getGrandTotal();
+        }
+
         // Check if coming from iframe or submit button
         if ((!Mage::getStoreConfig('payment/bitpay/fullscreen') && $iframe === false)
             || (Mage::getStoreConfig('payment/bitpay/fullscreen') && $iframe === true)) {
@@ -51,11 +60,6 @@ class Bitpay_Core_Model_Method_Bitcoin extends Mage_Payment_Model_Method_Abstrac
             }
 
             return $this;
-        }
-
-        if (false === isset($payment) || false === isset($amount) || true === empty($payment) || true === empty($amount)) {
-            $this->debugData('[ERROR] In Bitpay_Core_Model_Method_Bitcoin::authorize(): missing payment or amount parameters.');
-            throw new \Exception('In Bitpay_Core_Model_Method_Bitcoin::authorize(): missing payment or amount parameters.');
         }
 
         $this->debugData('[INFO] Bitpay_Core_Model_Method_Bitcoin::authorize(): authorizing new order.');

--- a/scripts/package
+++ b/scripts/package
@@ -11,7 +11,7 @@ date_default_timezone_set('America/New_York'); // Main Office is in Eastern Time
 /**
  * Various Configuration Settings
  */
-$version    = '2.1.10';
+$version    = '2.1.11';
 $vendorDir  = __DIR__ . '/../vendor';
 $distDir    = __DIR__ . '/../build/dist';
 $tmpDistDir = $distDir . '/tmp'; // Files will be placed here temporarly so we can zip/tar them.


### PR DESCRIPTION
closes #103 
- If shopping cart user's currency is not the same as the Magento configured base currency and the type of BitPay invoice is a redirected checkout (non iFrame), then the $amount (invoice amount) passed to Bitcoin.php authorize() will be in the base currency and not the user's currency. A BitPay invoice is then created based on the user's currency and the amount, which is wrong.

- The Bitcoin.php authorize function now recomputes the amount in the event that the amount is not correct.


- Updated the README and GUIDE to show latest Magento version checked.