### PR TITLE
Iframe invoice will create order

### DIFF
--- a/app/code/community/Bitpay/Core/Model/Method/Bitcoin.php
+++ b/app/code/community/Bitpay/Core/Model/Method/Bitcoin.php
@@ -46,19 +46,11 @@ class Bitpay_Core_Model_Method_Bitcoin extends Mage_Payment_Model_Method_Abstrac
             $amount = $payment->getOrder()->getQuote()->getGrandTotal();
         }
 
-        // Check if coming from iframe or submit button
+        // This means that this authorize method was called from a Magento checkout controller
+        // and not the iframe.phtml template while this plugin is in non-redirected checkout mode,
+        // therefore we shouldn't create a new invoice, we should just return the model
         if ((!Mage::getStoreConfig('payment/bitpay/fullscreen') && $iframe === false)
             || (Mage::getStoreConfig('payment/bitpay/fullscreen') && $iframe === true)) {
-            $quoteId = $payment->getOrder()->getQuoteId();
-            $ipn     = Mage::getModel('bitpay/ipn');
-
-            if (!$ipn->GetQuotePaid($quoteId))
-            {
-                // This is the error that is displayed to the customer during checkout.
-                Mage::throwException("Order not paid for.  Please pay first and then Place your Order.");
-                Mage::log('Order not paid for. Please pay first and then Place Your Order.', Zend_Log::CRIT, Mage::helper('bitpay')->getLogFile());
-            }
-
             return $this;
         }
 

--- a/app/design/frontend/base/default/template/bitpay/iframe.phtml
+++ b/app/design/frontend/base/default/template/bitpay/iframe.phtml
@@ -1,6 +1,6 @@
-<?php 
+<?php
 /**
- * @license Copyright 2011-2014 BitPay Inc., MIT License
+ * @license Copyright 2011-2016 BitPay Inc., MIT License
  * @see https://github.com/bitpay/magento-plugin/blob/master/LICENSE
  */
 
@@ -18,7 +18,7 @@ switch($url) {
         echo 'Error creating invoice.  Please try again or try another payment solution.';
         break;
     default:
-        echo '<iframe src="'.$url.'" style="width:500px; height:150px; overflow:hidden; border:none; margin:auto; display:block;" scrolling="no" allowtransparency="true" frameborder="0"> </iframe>';
+        echo '<iframe class="bitpay_invoice_iframe" src="'.$url.'" style="width:500px; height:150px; overflow:hidden; border:none; margin:auto; display:none;" scrolling="no" allowtransparency="true" frameborder="0"> </iframe>';
         break;
 }
 $quoteId = $this->getQuote()->getId();
@@ -27,23 +27,64 @@ $url     = Mage::getUrl('bitpay/index/index/');
 if ($request->getScheme() == 'https') {
     $url = str_replace('http://', 'https://', $url);
 }
+
 ?>
 <script type="text/javascript">
 //<![CDATA[
-new PeriodicalExecuter(function() {
-    new Ajax.Request(
-        "<?php echo $url . '?quote=' . $quoteId; ?>",
-        {
-            asynchronous: true,
-            evalScripts: true, 
-            onComplete: function(request, json) {
-                var data = request.responseText.evalJSON(); 
-                if (data.paid) { 
-                    review.save();
-                } 
-            }
+if ($$('iframe.bitpay_invoice_iframe').length > 0) {
+  var bpListener = {
+    nextStep: function(transport) {
+      if (transport && transport.responseText) {
+        try{
+          response = eval('(' + transport.responseText + ')');
         }
-    );
-}, 5);
+        catch (e) {
+          response = {};
+        }
+        if (response.success) {
+          $$('iframe.bitpay_invoice_iframe')[0].setStyle({display:'block'});
+          $$('button.btn-checkout')[0].setStyle({display:'none'});
+          var ipnPoller = new PeriodicalExecuter(function() {
+            new Ajax.Request("<?php echo $url . '?quote=' . $quoteId; ?>",
+              {
+                asynchronous: true,
+                evalScripts: true,
+                onComplete: function(request, json) {
+                var data = request.responseText.evalJSON();
+                if (data.paid) {
+                  ipnPoller.stop();
+                  review.nextStep(transport);
+                }
+              }
+            });
+          }, 5);
+        } else {
+          var msg = response.error_messages;
+          if (typeof(msg)=='object') {
+            msg = msg.join("\n");
+          }
+          if (msg) {
+            alert(msg);
+          }
+        }
+        if (response.update_section) {
+          $('checkout-'+response.update_section.name+'-load').update(response.update_section.html);
+        }
+        if (response.goto_section) {
+          checkout.gotoSection(response.goto_section, true);
+        }
+      }
+    }
+  };
+  var reviewCheck = new PeriodicalExecuter(function() {
+    if (review) {
+      reviewCheck.stop();
+      var originalSaveHandler = review.onSave;
+      review.onSave = bpListener.nextStep.bindAsEventListener(review);
+    }
+  }, 1);
+}
 //]]>
 </script>
+
+

--- a/scripts/config.json
+++ b/scripts/config.json
@@ -1,0 +1,11 @@
+{
+  "mysql": {
+    "host": "localhost",
+    "user": "magento",
+    "password": "magento",
+    "database": "magento"
+  },
+  "host": "http://127.0.0.1/magento/index.php/bitpay/ipn",
+  "status": "confirmed"
+}
+  

--- a/scripts/send_ipn_for_last_order_created.js
+++ b/scripts/send_ipn_for_last_order_created.js
@@ -1,0 +1,97 @@
+'use-strict'
+
+var mysql = require('mysql');
+var format = require('string-template');
+var query = 'select * from bitpay_invoices where quote_id=(select MAX(quote_id) from bitpay_invoices)';
+var spawn = require('child_process').spawn;
+var config = require('./config.json');
+var data = {};
+var connection = mysql.createConnection(config.mysql);
+
+function postIpn() {
+  connection.connect();
+  connection.query(query, processRows);
+}
+
+function send(curl_args) {
+  var curl = spawn('curl', curl_args);
+  var stderr;
+  curl.stdout.on('data', function(data) {
+    console.log(data.toString());
+  });
+  curl.stderr.on('data', function(data) {
+    stderr = data;
+  });
+  curl.on('close', function(code) {
+    if (code === 0) {
+      console.log('curl exited successfully');
+    } else {
+      console.log('curl exited with an error: ' + stderr);
+    }
+  });
+}
+
+function processRows(err, rows, fields) {
+  if (err) {
+    throw err;
+  }
+  var curl_args = [
+    '-X', 'POST', '-H',
+    'Content-Type: application/json',
+    '-H', "Content-Length: {length}",
+    '-H', 'Connection: close',
+    '-H', 'Accept: application/json',
+    '-d', '',
+    config.host ];
+  var convertedKeys = convertNames(fields);
+  var timeRegExp = new RegExp(/.*Time$/);
+  for (var i=0; i<convertedKeys.length; i++) {
+    var rowValue = rows[0][fields[i].name];
+    if (convertedKeys[i] === 'status') {
+      data[convertedKeys[i]] = config.status;
+    } else if (convertedKeys[i].match(timeRegExp)) {
+      data[convertedKeys[i]] = rowValue * 1000;
+    }
+    else {
+      data[convertedKeys[i]] = rowValue;
+    }
+  }
+  data.buyerFields = {};
+  data.url = 'https://test.bitpay.com:443/invoice?id=' + rows[0].id;
+  data.posData = '{\"quoteId\":\"' + rows[0].quote_id.toString() + '\"}';
+  data.btcPaid = data.btcPrice;
+  data.btcDue = '0.000000';
+  var jsonPayload = JSON.stringify(data);
+  curl_args[5] = format(curl_args[5], {length: jsonPayload.length});
+  curl_args[11] = jsonPayload;
+  connection.end();
+  send(curl_args);
+}
+
+function convertNames(names) {
+  var ret = [];
+  if (!names || typeof names !== 'object' || names.length === 0) {
+    return ret;
+  }
+
+  for (var j = 0; j < names.length; j++) {
+    var name = names[j].name;
+    var converted = name[0];
+    var i = 1;
+    while (i < (name.length - 1)) {
+      if (name[i] === '_') {
+        converted += name[i+1].toUpperCase();
+        i = i+2;
+      } else {
+        converted += name[i];
+        i++;
+      }
+    }
+    converted += name[name.length-1];
+    ret.push(converted);
+  }
+
+  return ret;
+}
+
+postIpn();


### PR DESCRIPTION
- For merchants using an iframe BitPay invoice (set "Redirect Checkout"
  to "No")
  - Before this change:
    - When a user confirms the payment method, the BitPay invoice will
      be displayed and the Magento order will not yet be created.
    - The Magento order is only created if the user pays the invoice,
      leaves the checkout browser window open, and BitPay is able to see
the user's transaction and send the IPN successfully to the Magento
server.
    - The problem is when the customer sends a bitcoin transaction, but
      their transaction isn't relayed because the fee is too low or the
network is under high load.
    - Under this condition, the customer has paid, yet they have no
      order with the merchant. The merchant has a hard time serving
their customer under these conditions.
  After this change:
    - When the user confirms their payment method, the BitPay invoice
      will NOT be displayed until the user clicks "Place Order".
    - This will guarantee that an order is created BEFORE the customer
      is able to pay the BitPay invoice.
    - This will allow the merchant to self-serve their customer by being
      able to find their customer in their dashboard and issue a refund
or apply the transaction.