### PR TITLE
Unified order creation to the same place as redirected check out.

### DIFF
--- a/app/code/community/Bitpay/Core/Block/Iframe.php
+++ b/app/code/community/Bitpay/Core/Block/Iframe.php
@@ -3,7 +3,6 @@
  * @license Copyright 2011-2014 BitPay Inc., MIT License
  * @see https://github.com/bitpay/magento-plugin/blob/master/LICENSE
  * 
- * TODO: Finish this iFrame implemenation... :/
  */
 
 class Bitpay_Core_Block_Iframe extends Mage_Checkout_Block_Onepage_Payment
@@ -24,6 +23,7 @@ class Bitpay_Core_Block_Iframe extends Mage_Checkout_Block_Onepage_Payment
     public function getIframeUrl()
     {
 
+	//by this time, we MUST have an order already created
         if (!($quote = Mage::getSingleton('checkout/session')->getQuote()) 
             or !($payment = $quote->getPayment())
             or !($paymentMethod = $payment->getMethod())
@@ -45,26 +45,6 @@ class Bitpay_Core_Block_Iframe extends Mage_Checkout_Block_Onepage_Payment
             return 'paid'; // quote's already paid, so don't show the iframe
         }
 
-        /*** @var Bitpay_Core_Model_PaymentMethod ***/
-        $method  = $this->getQuote()->getPayment()->getMethodInstance();
-
-        $amount = $this->getQuote()->getGrandTotal();
-
-        if (false === isset($method) || true === empty($method)) {
-            \Mage::helper('bitpay')->debugData('[ERROR] In Bitpay_Core_Block_Iframe::getIframeUrl(): Could not obtain an instance of the payment method.');
-            throw new \Exception('In Bitpay_Core_Block_Iframe::getIframeUrl(): Could not obtain an instance of the payment method.');
-        }
-
-        $bitcoinMethod = \Mage::getModel('bitpay/method_bitcoin');
-
-        try {
-            $bitcoinMethod->authorize($payment, $amount, true);
-        } catch (\Exception $e) {
-            \Mage::helper('bitpay')->debugData('[ERROR] In Bitpay_Core_Block_Iframe::getIframeUrl(): failed with the message: ' . $e->getMessage());
-            \Mage::throwException("Error creating BitPay invoice. Please try again or use another payment option.");
-            return false;
-        }
-
-        return $bitcoinMethod->getOrderPlaceRedirectUrl();
+        return 'bitpay';
     }
 }

--- a/app/code/community/Bitpay/Core/Block/Iframe.php
+++ b/app/code/community/Bitpay/Core/Block/Iframe.php
@@ -23,7 +23,6 @@ class Bitpay_Core_Block_Iframe extends Mage_Checkout_Block_Onepage_Payment
     public function getIframeUrl()
     {
 
-	//by this time, we MUST have an order already created
         if (!($quote = Mage::getSingleton('checkout/session')->getQuote()) 
             or !($payment = $quote->getPayment())
             or !($paymentMethod = $payment->getMethod())

--- a/app/code/community/Bitpay/Core/Model/Ipn.php
+++ b/app/code/community/Bitpay/Core/Model/Ipn.php
@@ -29,19 +29,20 @@ class Bitpay_Core_Model_Ipn extends Mage_Core_Model_Abstract
             return false;
         }
 
-        $quote = Mage::getModel('sales/quote')->load($quoteId, 'entity_id');
+        $order = \Mage::getModel('sales/order')->load($quoteId, 'quote_id');
 
-        if (!$quote)
-        {
-        	Mage::log('quote not found', Zend_Log::WARN, 'bitpay.log');
+        if (false === isset($order) || true === empty($order)) {
+            \Mage::helper('bitpay')->debugData('[DEBUG] Bitpay_Core_Model_Ipn::GetStatusReceived(), order not found for quoteId' . $quoteId);
             return false;
         }
 
+
+        $orderId = $order->getIncrementId();
         $collection = $this->getCollection();
 
         foreach ($collection as $i)
         {
-            if ($quoteId == json_decode($i->pos_data, true)['quoteId']) {
+            if ($orderId == json_decode($i->pos_data, true)['orderId']) {
                 if (in_array($i->status, $statuses)) {
                     return true;
                 }

--- a/app/code/community/Bitpay/Core/controllers/IndexController.php
+++ b/app/code/community/Bitpay/Core/controllers/IndexController.php
@@ -14,16 +14,21 @@ class Bitpay_Core_IndexController extends Mage_Core_Controller_Front_Action
      */
     public function indexAction()
     {
-        $params  = $this->getRequest()->getParams();
-        $quoteId = $params['quote'];
         \Mage::helper('bitpay')->registerAutoloader();
         \Mage::helper('bitpay')->debugData($params);
-        $paid = Mage::getModel('bitpay/ipn')->GetQuotePaid($quoteId);
 
+	$params  = $this->getRequest()->getParams();
+	$quoteId = $params['quote'];
+
+	if (!is_numeric($quoteId))
+	{
+	    return $this->getResponse()->setHttpResponseCode(400);
+	}
+
+        $paid = \Mage::getModel('bitpay/ipn')->GetQuotePaid($quoteId);
         $this->loadLayout();
-
         $this->getResponse()->setHeader('Content-type', 'application/json');
         
-        $this->getResponse()->setBody(json_encode(array('paid' => $paid)));
+        return $this->getResponse()->setBody(json_encode(array('paid' => $paid)));
     }
 }

--- a/app/design/frontend/base/default/template/bitpay/iframe.phtml
+++ b/app/design/frontend/base/default/template/bitpay/iframe.phtml
@@ -18,7 +18,7 @@ switch($url) {
         echo 'Error creating invoice.  Please try again or try another payment solution.';
         break;
     default:
-        echo '<iframe class="bitpay_invoice_iframe" src="'.$url.'" style="width:500px; height:150px; overflow:hidden; border:none; margin:auto; display:none;" scrolling="no" allowtransparency="true" frameborder="0"> </iframe>';
+        echo '<div class="bitpay_invoice_div" style="display:none; width:100%;"></div>';
         break;
 }
 $quoteId = $this->getQuote()->getId();
@@ -31,7 +31,7 @@ if ($request->getScheme() == 'https') {
 ?>
 <script type="text/javascript">
 //<![CDATA[
-if ($$('iframe.bitpay_invoice_iframe').length > 0) {
+if ($$('div.bitpay_invoice_div').length > 0) {
   var bpListener = {
     nextStep: function(transport) {
       if (transport && transport.responseText) {
@@ -42,17 +42,21 @@ if ($$('iframe.bitpay_invoice_iframe').length > 0) {
           response = {};
         }
         if (response.success) {
-          $$('iframe.bitpay_invoice_iframe')[0].setStyle({display:'block'});
           $$('button.btn-checkout')[0].setStyle({display:'none'});
+          var invoice_div = $$('div.bitpay_invoice_div')[0];
+          invoice_div.setStyle({display:'block'});
+          invoice_div.innerHTML = '<iframe class="bitpay_invoice_iframe" src="' + response.redirect + '" style="width:500px; height:150px; overflow:hidden; border:none; display:block; margin:auto; scrolling="no" allowtransparency="true" frameborder="0"></iframe>';
           var ipnPoller = new PeriodicalExecuter(function() {
             new Ajax.Request("<?php echo $url . '?quote=' . $quoteId; ?>",
-              {
-                asynchronous: true,
-                evalScripts: true,
-                onComplete: function(request, json) {
+            {
+              asynchronous: true,
+              evalScripts: true,
+              onComplete: function(request) {
                 var data = request.responseText.evalJSON();
                 if (data.paid) {
                   ipnPoller.stop();
+                  response.redirect = null;
+                  transport.responseText = JSON.stringify(response);
                   review.nextStep(transport);
                 }
               }

--- a/scripts/package
+++ b/scripts/package
@@ -11,7 +11,7 @@ date_default_timezone_set('America/New_York'); // Main Office is in Eastern Time
 /**
  * Various Configuration Settings
  */
-$version    = '2.1.11';
+$version    = '2.1.12';
 $vendorDir  = __DIR__ . '/../vendor';
 $distDir    = __DIR__ . '/../build/dist';
 $tmpDistDir = $distDir . '/tmp'; // Files will be placed here temporarly so we can zip/tar them.

--- a/scripts/send_ipn_for_last_order_created.js
+++ b/scripts/send_ipn_for_last_order_created.js
@@ -1,5 +1,3 @@
-'use-strict'
-
 var mysql = require('mysql');
 var format = require('string-template');
 var query = 'select * from bitpay_invoices where quote_id=(select MAX(quote_id) from bitpay_invoices)';
@@ -58,7 +56,7 @@ function processRows(err, rows, fields) {
   }
   data.buyerFields = {};
   data.url = 'https://test.bitpay.com:443/invoice?id=' + rows[0].id;
-  data.posData = '{\"quoteId\":\"' + rows[0].quote_id.toString() + '\"}';
+  data.posData = '{\"orderId\":\"' + rows[0].order_id.toString() + '\"}';
   data.btcPaid = data.btcPrice;
   data.btcDue = '0.000000';
   var jsonPayload = JSON.stringify(data);


### PR DESCRIPTION
- Redirected check out and iframe checkout share the same order creation logic.
- The order will be created during saveOrder call to backend. 
- The difference between the two will be injection of client-side javascript during payment type selection. 
	- if BitPay/Bitcoin, client-side JS will be inserted into page to swap the out the next step after order save is complete
	- in all cases, Magento will create the invoice and pass the client a redirect_url
	- the iframe invoice will receive the redirect url and build an iframe with the src being the bitpay url. 
	- the redirected check out will not have any new client side JS, so the next step will be to redirect from Magento.